### PR TITLE
Fix generation race that could lead to "Purchase not found"

### DIFF
--- a/src/app/api/generate-product/route.ts
+++ b/src/app/api/generate-product/route.ts
@@ -30,22 +30,25 @@ export async function POST(request: NextRequest) {
     deliveryUrl: `/delivery/${input.purchaseId}?token=demo`,
   });
 
-  void (async () => {
-    try {
-      setGenerationState(input.purchaseId, { status: "running", progress: 10, stage: "Starting generator" });
-      await generateProduct(input, (progress, stage) => {
-        setGenerationState(input.purchaseId, { status: "running", progress, stage });
-      });
-      setGenerationState(input.purchaseId, { status: "completed", progress: 100, stage: "Files ready" });
-    } catch (error) {
-      setGenerationState(input.purchaseId, {
-        status: "failed",
-        progress: 100,
-        stage: "Generation failed",
-        error: error instanceof Error ? error.message : "Unknown generation error",
-      });
-    }
-  })();
+  try {
+    setGenerationState(input.purchaseId, { status: "running", progress: 10, stage: "Starting generator" });
+    await generateProduct(input, (progress, stage) => {
+      setGenerationState(input.purchaseId, { status: "running", progress, stage });
+    });
+    setGenerationState(input.purchaseId, { status: "completed", progress: 100, stage: "Files ready" });
+  } catch (error) {
+    setGenerationState(input.purchaseId, {
+      status: "failed",
+      progress: 100,
+      stage: "Generation failed",
+      error: error instanceof Error ? error.message : "Unknown generation error",
+    });
+
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to generate product" },
+      { status: 500 }
+    );
+  }
 
   return NextResponse.json({
     purchaseId: input.purchaseId,


### PR DESCRIPTION
### Motivation
- Fix an intermittent race where the product-generation API returned before files (including `meta.json`) were persisted, causing delivery pages to render `Purchase not found`.
- Ensure generation state accurately reflects the real on-disk status so delivery pages reliably find generated artifacts.

### Description
- Changed `/api/generate-product` to run generation inline (awaiting `generateProduct`) instead of firing a detached background async task in the request handler.
- Continued to update progress via `setGenerationState` during generation (`queued` → `running` → `completed`) so UI still shows live progress.
- On generation failure the route now sets the `failed` state and returns an explicit `500` JSON error response to the client.
- The change ensures the route only returns success once `meta.json` and other purchase files have been written (via existing `writePurchaseFile` logic in `generateProduct`).

### Testing
- Ran `npm run lint` and it completed without ESLint errors (success).
- Ran `npm run build` and Next.js production build completed and sitemap generation succeeded (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69977cb9f1048331a37f6aa2e380dfe3)