### PR TITLE
Improve delivery fallback state instead of showing Purchase not found

### DIFF
--- a/src/app/delivery/[purchaseId]/page.tsx
+++ b/src/app/delivery/[purchaseId]/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import Link from "next/link";
+import { getGenerationState } from "@/lib/products/progress";
 import { readPurchaseMeta } from "@/lib/products/storage";
 
 export const dynamic = "force-dynamic";
@@ -24,7 +25,25 @@ export default async function DeliveryPage({ params, searchParams }: { params: {
   try {
     meta = await readPurchaseMeta(params.purchaseId);
   } catch {
-    return <main className="min-h-screen bg-white px-6 py-20"><div className="mx-auto max-w-xl">Purchase not found.</div></main>;
+    const generationState = getGenerationState(params.purchaseId);
+
+    return (
+      <main className="min-h-screen bg-white px-6 py-20">
+        <div className="mx-auto max-w-xl rounded-xl border border-slate-200 p-8 text-center">
+          <h1 className="text-2xl font-bold text-slate-900">We&apos;re still preparing your files</h1>
+          <p className="mt-3 text-slate-600">
+            {generationState
+              ? `${generationState.stage} (${generationState.progress}%)`
+              : "This purchase may still be generating. Please refresh in a moment."}
+          </p>
+          {generationState?.error ? <p className="mt-2 text-sm text-red-600">{generationState.error}</p> : null}
+          <div className="mt-6 flex justify-center gap-4">
+            <a href={`/delivery/${params.purchaseId}?token=demo`} className="inline-flex rounded-md bg-emerald-600 px-4 py-2 text-white">Refresh</a>
+            <Link href="/pricing" className="inline-flex rounded-md border border-slate-300 px-4 py-2 text-slate-700">Go to Pricing</Link>
+          </div>
+        </div>
+      </main>
+    );
   }
 
   return (

--- a/src/lib/products/storage.ts
+++ b/src/lib/products/storage.ts
@@ -47,12 +47,14 @@ export async function readPurchaseMeta(purchaseId: string) {
     const stats = await Promise.all(
       fileNames.map(async (fileName) => fs.stat(getPurchaseFilePath(purchaseId, fileName)).catch(() => null))
     );
-    const createdAt = stats
-      .filter((stat): stat is Awaited<ReturnType<typeof fs.stat>> => !!stat)
-      .reduce<string>((latest, stat) => {
-        const candidate = stat.mtime.toISOString();
-        return candidate > latest ? candidate : latest;
-      }, new Date(0).toISOString());
+    const createdAt = stats.reduce<string>((latest, stat) => {
+      if (!stat) {
+        return latest;
+      }
+
+      const candidate = stat.mtime.toISOString();
+      return candidate > latest ? candidate : latest;
+    }, new Date(0).toISOString());
 
     return {
       purchaseId,


### PR DESCRIPTION
### Motivation
- When purchase metadata is missing the page returned a hard `Purchase not found.` message, which is confusing for in-progress generation flows. 
- Provide a clearer recovery experience by surfacing in-memory generation progress and actions to refresh or return to pricing.

### Description
- Update `src/app/delivery/[purchaseId]/page.tsx` to import `getGenerationState` and show a “We’re still preparing your files” fallback that displays `stage` and `progress` (when available), any generation `error`, and actions to refresh the delivery URL or go back to pricing. 
- Simplify `createdAt` computation in `src/lib/products/storage.ts` by using a `reduce` that gracefully skips null `stat` results instead of an explicit filter/type-guard approach. 
- The fallback replaces the previous immediate error response and surfaces in-memory generation state for better UX during simulated/demo generation.

### Testing
- Ran `npm run build`, which completed successfully and produced the optimized production build. 
- Started the dev server and executed a Playwright script to navigate to `/delivery/test-purchase-123?token=demo` and capture a screenshot to validate the updated fallback UI, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997779652948331be579ea09890f313)